### PR TITLE
Add '[SecureContext]` tags to the interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -274,7 +274,7 @@ field can be accessed by the user agent.
 ## {{ContactAddress}} ## {#contact-address}
 
 <script type="idl">
-[Exposed=Window]
+[Exposed=Window, SecureContext]
 interface ContactAddress {
   [Default] object toJSON();
   readonly attribute DOMString city;
@@ -343,7 +343,7 @@ dictionary ContactsSelectOptions {
     boolean multiple = false;
 };
 
-[Exposed=Window,SecureContext]
+[Exposed=Window, SecureContext]
 interface ContactsManager {
     Promise<sequence<ContactProperty>> getProperties();
     Promise<sequence<ContactInfo>> select(sequence<ContactProperty> properties, optional ContactsSelectOptions options = {});


### PR DESCRIPTION
- Related to https://github.com/w3c/webref/issues/1142#issuecomment-1924200755

`w3c/webref` repo automatically extracts syntaxes from these spec docs. At the moment some syntax sections are missing the `[SecureContext]` tags so it is [missing from extracted data in webref as well](https://github.com/w3c/webref/blob/1ebc07b4638f130623f054e556da62fd6a045e01/ed/idl/cookie-store.idl#L92).

The feature has been [marked available in secure context in MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/ContactAddress). 

The PR adds the tags to the ContactAddress interface.